### PR TITLE
feat: 시스템로그 기능에서 누락된 항목 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY ./app ./app
 COPY ./db ./db
 COPY ./alembic.ini .
 COPY ./alembic ./alembic
+COPY ./logging.ini .
 
 # 파일 소유권을 non-root 사용자로 변경
 RUN chown -R appuser:appgroup /app


### PR DESCRIPTION
Dockerfile에 logging.ini 카피가 누락되어 추가